### PR TITLE
fix(editor): add watcher for readonly state changes

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -258,6 +258,11 @@
                 this.editor.commands.setContent(val);
                 this.updateValue(this.editor.getHTML());
             },
+            'currentField.readonly': function (val) {
+                if (this.editor) {
+                    this.editor.setEditable(!val);
+                }
+            }
         },
 
         computed: {


### PR DESCRIPTION
This PR adds a watcher on `currentField.readonly` to properly handle the editor's editable state when it changes through `dependsOn`, especially when using the `translatable()` method from nova-translatable package.

The solution ensures that the editor's editable state is properly updated whenever the readonly state changes, fixing the compatibility issue between the two packages.