### PR TITLE
Add linode as a allowed disk

### DIFF
--- a/config/nova-tiptap.php
+++ b/config/nova-tiptap.php
@@ -91,7 +91,7 @@ return [
          | Allowed storage disks for uploads
          | For security, only allow specific disks
          */
-        'allowed_disks' => ['public', 'local'],
+        'allowed_disks' => ['public', 'local', 'linode'],
 
         /*
          | Enable strict MIME type checking

--- a/config/nova-tiptap.php
+++ b/config/nova-tiptap.php
@@ -91,7 +91,7 @@ return [
          | Allowed storage disks for uploads
          | For security, only allow specific disks
          */
-        'allowed_disks' => ['public', 'local', 'linode'],
+        'allowed_disks' => explode(',', env('NOVA_TIP_TAP_ALLOWED_DISKS', 'public,local')),
 
         /*
          | Enable strict MIME type checking


### PR DESCRIPTION
We’re using Linode as an S3-compatible service to store our images. Recently, we ran into an issue while trying to update photos in production. After some digging, we found that the problem was in the configuration file. This small fix should be helpful for others who are also using Linode for image storage.